### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -26,10 +26,10 @@ Authors
 =======
 
 Invenio-Groups is a module developed for the `Invenio
-<http://invenio-software.org>`_ digital library software.
+<http://inveniosoftware.org>`_ digital library software.
 
-Contact us at `info@invenio-software.org
-<mailto:info@invenio-software.org>`_.
+Contact us at `info@inveniosoftware.org
+<mailto:info@inveniosoftware.org>`_.
 
 - Adrian Pawel Baran <adrian.pawel.baran@cern.ch>
 - Benoit Thiell <bthiell@cfa.harvard.edu>

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -29,8 +29,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-Groups.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-groups
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/examples/app.py
+++ b/examples/app.py
@@ -88,12 +88,12 @@ def users():
         PrivacyPolicy, SubscriptionPolicy
 
     admin = accounts.datastore.create_user(
-        email='admin@invenio-software.org',
+        email='admin@inveniosoftware.org',
         password=encrypt_password('123456'),
         active=True,
     )
     reader = accounts.datastore.create_user(
-        email='reader@invenio-software.org',
+        email='reader@inveniosoftware.org',
         password=encrypt_password('123456'),
         active=True,
     )

--- a/invenio_groups/translations/messages.pot
+++ b/invenio_groups/translations/messages.pot
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-groups 0.1.2\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-08-25 18:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ directory = invenio_groups/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@invenio-software.org
+msgid_bugs_address = info@inveniosoftware.org
 mapping-file = babel.ini
 output-file = invenio_groups/translations/messages.pot
 add-comments = NOTE

--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ setup(
     keywords='invenio groups',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-groups',
     packages=packages,
     zip_safe=False,


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>